### PR TITLE
Remove use of parser class

### DIFF
--- a/Factory.php
+++ b/Factory.php
@@ -5,13 +5,8 @@
 namespace Graviton\RqlParserBundle;
 
 use Doctrine\ODM\MongoDB\Query\Builder;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Xiag\Rql\Parser\Lexer;
-use Xiag\Rql\Parser\Parser as RqlParser;
-use Xiag\Rql\Parser\Exception\SyntaxErrorException;
 use Graviton\RqlParserBundle\Exceptions\VisitorInterfaceNotImplementedException;
 use Graviton\RqlParserBundle\Exceptions\VisitorNotSupportedException;
-use Graviton\Rql\Parser;
 use Graviton\Rql\Visitor\VisitorInterface;
 
 /**
@@ -22,21 +17,6 @@ use Graviton\Rql\Visitor\VisitorInterface;
 class Factory
 {
     /**
-     * @var Parser
-     */
-    protected $parser;
-
-    /**
-     * @var Lexer
-     */
-    private $lexer;
-
-    /**
-     * @var RqlParser
-     */
-    private $rqlParser;
-
-    /**
      * @var array Set of supported Visitors
      */
     protected $supportedVisitors = array(
@@ -44,43 +24,16 @@ class Factory
     );
 
     /**
-     * @param Lexer     $lexer     lexer
-     * @param RqlParser $rqlParser parser
-     */
-    public function __construct(Lexer $lexer, RqlParser $rqlParser)
-    {
-        $this->lexer = $lexer;
-        $this->rqlParser = $rqlParser;
-    }
-
-
-    /**
      * Provides an instance of the RQL Visitor.
      *
      * @param string  $visitorName  Name of the visitor class
-     * @param string  $rqlQuery     RQL formats string
      * @param Builder $queryBuilder Doctrine QueryBuilder
      *
-     * @return Parser
+     * @return Query
      */
-    public function create($visitorName, $rqlQuery, Builder $queryBuilder = null)
+    public function create($visitorName, Builder $queryBuilder = null)
     {
-        $visitor = $this->initVisitor($visitorName, $queryBuilder);
-        $this->parser = $this->initParser($visitor);
-
-        try {
-            $this->parser->parse($rqlQuery);
-        } catch (SyntaxErrorException $e) {
-            throw new BadRequestHttpException(
-                sprintf(
-                    'syntax error in rql: %s',
-                    $e->getMessage()
-                ),
-                $e
-            );
-        }
-
-        return $this->parser;
+        return $this->initVisitor($visitorName, $queryBuilder);
     }
 
     /**
@@ -108,22 +61,6 @@ class Factory
         }
 
         return $visitor;
-    }
-
-    /**
-     * Provides an instance of the Rql Parser.
-     *
-     * @param VisitorInterface $visitor rql visitor
-     *
-     * @return Parser
-     */
-    protected function initParser(VisitorInterface $visitor)
-    {
-        return new Parser(
-            $this->lexer,
-            $this->rqlParser,
-            $visitor
-        );
     }
 
     /**

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -5,21 +5,15 @@
         http://symfony.com/schema/dic/services/services-1.0.xsd"
         >
     <parameters>
-        <parameter key="graviton.rql.factory.class">Graviton\RqlParserBundle\Factory</parameter>
-        <parameter key="graviton.rql.rql.lexer.class">Xiag\Rql\Parser\Lexer</parameter>
-        <parameter key="graviton.rql.rql.parser.class">Xiag\Rql\Parser\Parser</parameter>
+        <parameter key="graviton.rql.lexer.class">Xiag\Rql\Parser\Lexer</parameter>
+        <parameter key="graviton.rql.parser.class">Xiag\Rql\Parser\Parser</parameter>
+        <parameter key="graviton.rql.visitor_factory.class">Graviton\RqlParserBundle\Factory</parameter>
     </parameters>
     <services>
-        <!-- Factory -->
-        <service id="graviton.rql.factory" class="Graviton\RqlParserBundle\Factory">
-            <argument type="service" id="graviton.rql.rql.lexer"/>
-            <argument type="service" id="graviton.rql.rql.parser"/>
+        <service id="graviton.rql.lexer" class="%graviton.rql.lexer.class%"/>
+        <service id="graviton.rql.parser" class="%graviton.rql.parser.class%">
+            <factory class="%graviton.rql.parser.class%" method="createDefault"/>
         </service>
-
-        <service id="graviton.rql.rql.lexer" class="%graviton.rql.rql.lexer.class%"/>
-
-        <service id="graviton.rql.rql.parser" class="%graviton.rql.rql.parser.class%">
-            <factory class="%graviton.rql.rql.parser.class%" method="createDefault"/>
-        </service>
+        <service id="graviton.rql.visitor_factory" class="%graviton.rql.visitor_factory.class%"/>
     </services>
 </container>

--- a/Tests/FactoryTest.php
+++ b/Tests/FactoryTest.php
@@ -6,7 +6,6 @@
 namespace Graviton\RqlParserBundle\Tests;
 
 use lapistano\ProxyObject\ProxyBuilder;
-use Xiag\Rql\Parser\Exception\SyntaxErrorException;
 
 /**
  * @author List of contributors <https://github.com/libgraviton/GravitonRqlParserBundle/graphs/contributors>
@@ -77,12 +76,6 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testSupportsClass()
     {
-        $lexerDouble = $this->getMock('Xiag\Rql\Parser\Lexer');
-        $rqlParserDouble = $this
-            ->getMockBuilder('Xiag\Rql\Parser\Parser')
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $factory = $this->getProxyBuilder('\Graviton\RqlParserBundle\Factory')
             ->setMethods(array('supportsClass'))
             ->getProxy();
@@ -99,12 +92,6 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testClassImplementsVisitorInterface()
     {
-        $lexerDouble = $this->getMock('Xiag\Rql\Parser\Lexer');
-        $rqlParserDouble = $this
-            ->getMockBuilder('Xiag\Rql\Parser\Parser')
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $factory = $this->getProxyBuilder('\Graviton\RqlParserBundle\Factory')
             ->setProperties(array('supportedVisitors'))
             ->setMethods(array('classImplementsVisitorInterface'))

--- a/Tests/FactoryTest.php
+++ b/Tests/FactoryTest.php
@@ -22,41 +22,13 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testCreate()
     {
-        $parserDouble = $this->getMockBuilder('\Graviton\Rql\Parser')
-            ->disableOriginalConstructor()
-            ->setMethods(array('parse', 'buildQuery'))
-            ->getMock();
-
-        $tokenDouble = $this
-            ->getMockBuilder('Xiag\Rql\Parser\TokenStream')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $lexerDouble = $this->getMock('Xiag\Rql\Parser\Lexer');
-
-        $lexerDouble->expects($this->once())
-            ->method('tokenize')
-            ->willReturn($tokenDouble);
-
-        $rqlParserDouble = $this
-            ->getMockBuilder('Xiag\Rql\Parser\Parser')
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $factory = $this->getProxyBuilder('\Graviton\RqlParserBundle\Factory')
-            ->setConstructorArgs(
-                [
-                    $lexerDouble,
-                    $rqlParserDouble
-                ]
-            )
-            ->setProperties(array('supportedVisitors', 'parser'))
+            ->setProperties(array('supportedVisitors'))
             ->getProxy();
 
         $factory->supportedVisitors['noop'] = '\Graviton\RqlParserBundle\Tests\Fixtures\NoopVisitor';
-        $factory->parser = $parserDouble;
 
-        $this->assertInstanceOf('Graviton\Rql\Parser', $factory->create('NoOp', ''));
+        $this->assertInstanceOf('Graviton\Rql\Visitor\VisitorInterface', $factory->create('NoOp'));
     }
 
     /**
@@ -72,19 +44,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $lexerDouble = $this->getMock('Xiag\Rql\Parser\Lexer');
-        $rqlParserDouble = $this
-            ->getMockBuilder('Xiag\Rql\Parser\Parser')
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $factory = $this->getProxyBuilder('\Graviton\RqlParserBundle\Factory')
-            ->setConstructorArgs(
-                [
-                    $lexerDouble,
-                    $rqlParserDouble
-                ]
-            )
             ->setProperties(array('supportedVisitors'))
             ->setMethods(array('initVisitor'))
             ->getProxy();
@@ -111,34 +71,6 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * validate parser initialization
-     *
-     * @return void
-     */
-    public function testInitParser()
-    {
-        $lexerDouble = $this->getMock('Xiag\Rql\Parser\Lexer');
-        $rqlParserDouble = $this
-            ->getMockBuilder('Xiag\Rql\Parser\Parser')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $factory = $this->getProxyBuilder('\Graviton\RqlParserBundle\Factory')
-            ->setConstructorArgs(
-                [
-                    $lexerDouble,
-                    $rqlParserDouble
-                ]
-            )
-            ->setMethods(array('initParser'))
-            ->getProxy();
-
-        $visitorDouble = $this->getMock('Graviton\Rql\Visitor\VisitorInterface');
-
-        $this->assertInstanceOf('\Graviton\Rql\Parser', $factory->initParser($visitorDouble));
-    }
-
-    /**
      * validate supportsClass method
      *
      * @return void
@@ -152,12 +84,6 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $factory = $this->getProxyBuilder('\Graviton\RqlParserBundle\Factory')
-            ->setConstructorArgs(
-                [
-                    $lexerDouble,
-                    $rqlParserDouble
-                ]
-            )
             ->setMethods(array('supportsClass'))
             ->getProxy();
 
@@ -180,12 +106,6 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $factory = $this->getProxyBuilder('\Graviton\RqlParserBundle\Factory')
-            ->setConstructorArgs(
-                [
-                    $lexerDouble,
-                    $rqlParserDouble
-                ]
-            )
             ->setProperties(array('supportedVisitors'))
             ->setMethods(array('classImplementsVisitorInterface'))
             ->getProxy();
@@ -195,57 +115,6 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('\Graviton\RqlParserBundle\Exceptions\VisitorInterfaceNotImplementedException');
 
         $factory->classImplementsVisitorInterface('NoOp');
-    }
-
-    /**
-     * validate that syntax errors are rethrown as bar request exceptions
-     *
-     * @return void
-     */
-    public function testCreateThrowsExceptionOnInvalidRql()
-    {
-        $parserDouble = $this->getMockBuilder('\Graviton\Rql\Parser')
-            ->disableOriginalConstructor()
-            ->setMethods(array('parse', 'buildQuery'))
-            ->getMock();
-
-        $tokenDouble = $this
-            ->getMockBuilder('Xiag\Rql\Parser\TokenStream')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $lexerDouble = $this->getMock('Xiag\Rql\Parser\Lexer');
-
-        $lexerDouble->expects($this->once())
-            ->method('tokenize')
-            ->willReturn($tokenDouble);
-
-        $rqlParserDouble = $this
-            ->getMockBuilder('Xiag\Rql\Parser\Parser')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $rqlParserDouble
-            ->expects($this->once())
-            ->method('parse')
-            ->will($this->throwException(new SyntaxErrorException));
-
-        $factory = $this->getProxyBuilder('\Graviton\RqlParserBundle\Factory')
-            ->setConstructorArgs(
-                [
-                    $lexerDouble,
-                    $rqlParserDouble
-                ]
-            )
-            ->setProperties(array('supportedVisitors', 'parser'))
-            ->getProxy();
-
-        $factory->supportedVisitors['noop'] = '\Graviton\RqlParserBundle\Tests\Fixtures\NoopVisitor';
-        $factory->parser = $parserDouble;
-
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\BadRequestHttpException');
-
-        $factory->create('NoOp', 'invalide=rql&inout(=];');
     }
 
     /**

--- a/composer.lock
+++ b/composer.lock
@@ -604,16 +604,16 @@
         },
         {
             "name": "graviton/php-rql-parser",
-            "version": "dev-develop",
+            "version": "v2.0.0-alpha9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/libgraviton/php-rql-parser.git",
-                "reference": "f03880baf9321a0bebea02a482e0cc5536aef302"
+                "reference": "90d52c13aa4acb5ad0a1e2dc192ab25d5bb6ce4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/libgraviton/php-rql-parser/zipball/f03880baf9321a0bebea02a482e0cc5536aef302",
-                "reference": "f03880baf9321a0bebea02a482e0cc5536aef302",
+                "url": "https://api.github.com/repos/libgraviton/php-rql-parser/zipball/90d52c13aa4acb5ad0a1e2dc192ab25d5bb6ce4e",
+                "reference": "90d52c13aa4acb5ad0a1e2dc192ab25d5bb6ce4e",
                 "shasum": ""
             },
             "require": {
@@ -656,7 +656,7 @@
                 "rest",
                 "rql"
             ],
-            "time": "2015-07-27 10:52:22"
+            "time": "2015-07-27 13:04:21"
         },
         {
             "name": "psr/log",
@@ -2797,7 +2797,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "graviton/php-rql-parser": 20,
+        "graviton/php-rql-parser": 15,
         "lapistano/proxy-object": 20,
         "doctrine/mongodb-odm": 10
     },

--- a/composer.lock
+++ b/composer.lock
@@ -604,16 +604,16 @@
         },
         {
             "name": "graviton/php-rql-parser",
-            "version": "v2.0.0-alpha7",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/libgraviton/php-rql-parser.git",
-                "reference": "8899721f676cb87b1f68b67a88d2b7c29ae6e77b"
+                "reference": "f03880baf9321a0bebea02a482e0cc5536aef302"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/libgraviton/php-rql-parser/zipball/8899721f676cb87b1f68b67a88d2b7c29ae6e77b",
-                "reference": "8899721f676cb87b1f68b67a88d2b7c29ae6e77b",
+                "url": "https://api.github.com/repos/libgraviton/php-rql-parser/zipball/f03880baf9321a0bebea02a482e0cc5536aef302",
+                "reference": "f03880baf9321a0bebea02a482e0cc5536aef302",
                 "shasum": ""
             },
             "require": {
@@ -656,7 +656,7 @@
                 "rest",
                 "rql"
             ],
-            "time": "2015-06-22 16:25:26"
+            "time": "2015-07-27 10:52:22"
         },
         {
             "name": "psr/log",
@@ -698,16 +698,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Console.git",
-                "reference": "564398bc1f33faf92fc2ec86859983d30eb81806"
+                "reference": "8cf484449130cabfd98dcb4694ca9945802a21ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/564398bc1f33faf92fc2ec86859983d30eb81806",
-                "reference": "564398bc1f33faf92fc2ec86859983d30eb81806",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/8cf484449130cabfd98dcb4694ca9945802a21ed",
+                "reference": "8cf484449130cabfd98dcb4694ca9945802a21ed",
                 "shasum": ""
             },
             "require": {
@@ -751,20 +751,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-10 15:30:22"
+            "time": "2015-07-09 16:07:40"
         },
         {
             "name": "symfony/debug",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Debug.git",
-                "reference": "075070230c5bbc65abde8241191655bbce0716e2"
+                "reference": "9daa1bf9f7e615fa2fba30357e479a90141222e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Debug/zipball/075070230c5bbc65abde8241191655bbce0716e2",
-                "reference": "075070230c5bbc65abde8241191655bbce0716e2",
+                "url": "https://api.github.com/repos/symfony/Debug/zipball/9daa1bf9f7e615fa2fba30357e479a90141222e3",
+                "reference": "9daa1bf9f7e615fa2fba30357e479a90141222e3",
                 "shasum": ""
             },
             "require": {
@@ -811,20 +811,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-08 09:37:21"
+            "time": "2015-07-09 16:07:40"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/EventDispatcher.git",
-                "reference": "be3c5ff8d503c46768aeb78ce6333051aa6f26d9"
+                "reference": "9310b5f9a87ec2ea75d20fec0b0017c77c66dac3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/be3c5ff8d503c46768aeb78ce6333051aa6f26d9",
-                "reference": "be3c5ff8d503c46768aeb78ce6333051aa6f26d9",
+                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/9310b5f9a87ec2ea75d20fec0b0017c77c66dac3",
+                "reference": "9310b5f9a87ec2ea75d20fec0b0017c77c66dac3",
                 "shasum": ""
             },
             "require": {
@@ -869,20 +869,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-08 09:37:21"
+            "time": "2015-06-18 19:21:56"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/HttpFoundation.git",
-                "reference": "4f363c426b0ced57e3d14460022feb63937980ff"
+                "reference": "88903c0531b90d4ecd90282b18f08c0c77bde0b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/HttpFoundation/zipball/4f363c426b0ced57e3d14460022feb63937980ff",
-                "reference": "4f363c426b0ced57e3d14460022feb63937980ff",
+                "url": "https://api.github.com/repos/symfony/HttpFoundation/zipball/88903c0531b90d4ecd90282b18f08c0c77bde0b2",
+                "reference": "88903c0531b90d4ecd90282b18f08c0c77bde0b2",
                 "shasum": ""
             },
             "require": {
@@ -922,20 +922,20 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-10 15:30:22"
+            "time": "2015-07-09 16:07:40"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/HttpKernel.git",
-                "reference": "208101c7a11e31933183bd2a380486e528c74302"
+                "reference": "4a8a6f2a847475b3a38da50363a07f69b5cbf37e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/HttpKernel/zipball/208101c7a11e31933183bd2a380486e528c74302",
-                "reference": "208101c7a11e31933183bd2a380486e528c74302",
+                "url": "https://api.github.com/repos/symfony/HttpKernel/zipball/4a8a6f2a847475b3a38da50363a07f69b5cbf37e",
+                "reference": "4a8a6f2a847475b3a38da50363a07f69b5cbf37e",
                 "shasum": ""
             },
             "require": {
@@ -1002,7 +1002,7 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-11 21:15:28"
+            "time": "2015-07-13 19:27:49"
         },
         {
             "name": "xiag/rql-parser",
@@ -1286,16 +1286,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.1.6",
+            "version": "2.1.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "631e365cf26bb2c078683e8d9bcf8bc631ac4d44"
+                "reference": "5bd48b86cd282da411bb80baac1398ce3fefac41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/631e365cf26bb2c078683e8d9bcf8bc631ac4d44",
-                "reference": "631e365cf26bb2c078683e8d9bcf8bc631ac4d44",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/5bd48b86cd282da411bb80baac1398ce3fefac41",
+                "reference": "5bd48b86cd282da411bb80baac1398ce3fefac41",
                 "shasum": ""
             },
             "require": {
@@ -1344,20 +1344,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-06-19 07:11:55"
+            "time": "2015-07-26 12:54:47"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "a923bb15680d0089e2316f7a4af8f437046e96bb"
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a923bb15680d0089e2316f7a4af8f437046e96bb",
-                "reference": "a923bb15680d0089e2316f7a4af8f437046e96bb",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
                 "shasum": ""
             },
             "require": {
@@ -1391,7 +1391,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-04-02 05:19:05"
+            "time": "2015-06-21 13:08:43"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1436,16 +1436,16 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.6",
+            "version": "1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "83fe1bdc5d47658b727595c14da140da92b3d66d"
+                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/83fe1bdc5d47658b727595c14da140da92b3d66d",
-                "reference": "83fe1bdc5d47658b727595c14da140da92b3d66d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
+                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
                 "shasum": ""
             },
             "require": {
@@ -1473,7 +1473,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2015-06-13 07:35:30"
+            "time": "2015-06-21 08:01:12"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -1526,16 +1526,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.7.5",
+            "version": "4.7.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f6701ef3faea759acd1910a7751d8d102a7fd5bc"
+                "reference": "9b97f9d807b862c2de2a36e86690000801c85724"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f6701ef3faea759acd1910a7751d8d102a7fd5bc",
-                "reference": "f6701ef3faea759acd1910a7751d8d102a7fd5bc",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9b97f9d807b862c2de2a36e86690000801c85724",
+                "reference": "9b97f9d807b862c2de2a36e86690000801c85724",
                 "shasum": ""
             },
             "require": {
@@ -1594,26 +1594,27 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-06-21 07:23:36"
+            "time": "2015-07-13 11:28:34"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.4",
+            "version": "2.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "92408bb1968a81b3217a6fdf6c1a198da83caa35"
+                "reference": "18dfbcb81d05e2296c0bcddd4db96cade75e6f42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/92408bb1968a81b3217a6fdf6c1a198da83caa35",
-                "reference": "92408bb1968a81b3217a6fdf6c1a198da83caa35",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/18dfbcb81d05e2296c0bcddd4db96cade75e6f42",
+                "reference": "18dfbcb81d05e2296c0bcddd4db96cade75e6f42",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "~1.0,>=1.0.2",
                 "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2"
+                "phpunit/php-text-template": "~1.2",
+                "sebastian/exporter": "~1.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.4"
@@ -1649,20 +1650,20 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-06-11 15:55:48"
+            "time": "2015-07-10 06:54:24"
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.1.1",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "1dd8869519a225f7f2b9eb663e225298fade819e"
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1dd8869519a225f7f2b9eb663e225298fade819e",
-                "reference": "1dd8869519a225f7f2b9eb663e225298fade819e",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
                 "shasum": ""
             },
             "require": {
@@ -1676,7 +1677,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -1713,7 +1714,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-01-29 16:28:08"
+            "time": "2015-07-26 15:48:44"
         },
         {
             "name": "sebastian/diff",
@@ -1769,16 +1770,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "1.2.2",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "5a8c7d31914337b69923db26c4221b81ff5a196e"
+                "reference": "4fe0a44cddd8cc19583a024bdc7374eb2fef0b87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5a8c7d31914337b69923db26c4221b81ff5a196e",
-                "reference": "5a8c7d31914337b69923db26c4221b81ff5a196e",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/4fe0a44cddd8cc19583a024bdc7374eb2fef0b87",
+                "reference": "4fe0a44cddd8cc19583a024bdc7374eb2fef0b87",
                 "shasum": ""
             },
             "require": {
@@ -1815,20 +1816,20 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2015-01-01 10:01:08"
+            "time": "2015-07-26 06:42:57"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "84839970d05254c73cde183a721c7af13aede943"
+                "reference": "7ae5513327cb536431847bcc0c10edba2701064e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/84839970d05254c73cde183a721c7af13aede943",
-                "reference": "84839970d05254c73cde183a721c7af13aede943",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/7ae5513327cb536431847bcc0c10edba2701064e",
+                "reference": "7ae5513327cb536431847bcc0c10edba2701064e",
                 "shasum": ""
             },
             "require": {
@@ -1881,7 +1882,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2015-01-27 07:23:06"
+            "time": "2015-06-21 07:55:53"
         },
         {
             "name": "sebastian/global-state",
@@ -1936,16 +1937,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "3989662bbb30a29d20d9faa04a846af79b276252"
+                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/3989662bbb30a29d20d9faa04a846af79b276252",
-                "reference": "3989662bbb30a29d20d9faa04a846af79b276252",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/994d4a811bafe801fb06dccbee797863ba2792ba",
+                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba",
                 "shasum": ""
             },
             "require": {
@@ -1985,7 +1986,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-01-24 09:48:32"
+            "time": "2015-06-21 08:04:50"
         },
         {
             "name": "sebastian/version",
@@ -2098,7 +2099,7 @@
         },
         {
             "name": "symfony/asset",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/asset.git",
@@ -2151,16 +2152,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Config.git",
-                "reference": "58ded81f1f582a87c528ef3dae9a859f78b5f374"
+                "reference": "6c905bbed1e728226de656e4c07d620dfe9e80d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Config/zipball/58ded81f1f582a87c528ef3dae9a859f78b5f374",
-                "reference": "58ded81f1f582a87c528ef3dae9a859f78b5f374",
+                "url": "https://api.github.com/repos/symfony/Config/zipball/6c905bbed1e728226de656e4c07d620dfe9e80d9",
+                "reference": "6c905bbed1e728226de656e4c07d620dfe9e80d9",
                 "shasum": ""
             },
             "require": {
@@ -2197,20 +2198,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-11 14:06:56"
+            "time": "2015-07-09 16:07:40"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/DependencyInjection.git",
-                "reference": "1a409e52a38ec891de0a7a61a191d1c62080b69d"
+                "reference": "d56b1b89a0c8b34a6eca6211ec76c43256ec4030"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/DependencyInjection/zipball/1a409e52a38ec891de0a7a61a191d1c62080b69d",
-                "reference": "1a409e52a38ec891de0a7a61a191d1c62080b69d",
+                "url": "https://api.github.com/repos/symfony/DependencyInjection/zipball/d56b1b89a0c8b34a6eca6211ec76c43256ec4030",
+                "reference": "d56b1b89a0c8b34a6eca6211ec76c43256ec4030",
                 "shasum": ""
             },
             "require": {
@@ -2257,20 +2258,20 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-11 19:13:11"
+            "time": "2015-07-09 16:07:40"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Filesystem.git",
-                "reference": "a0d43eb3e17d4f4c6990289805a488a0482a07f3"
+                "reference": "2d7b2ddaf3f548f4292df49a99d19c853d43f0b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/a0d43eb3e17d4f4c6990289805a488a0482a07f3",
-                "reference": "a0d43eb3e17d4f4c6990289805a488a0482a07f3",
+                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/2d7b2ddaf3f548f4292df49a99d19c853d43f0b8",
+                "reference": "2d7b2ddaf3f548f4292df49a99d19c853d43f0b8",
                 "shasum": ""
             },
             "require": {
@@ -2306,20 +2307,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-08 09:37:21"
+            "time": "2015-07-09 16:07:40"
         },
         {
             "name": "symfony/framework-bundle",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/FrameworkBundle.git",
-                "reference": "dee055c00ac76bb079439aac4ec04897f00e1d43"
+                "reference": "a796b26e4fa0afddadfd42e2fd374974dd68ced2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/FrameworkBundle/zipball/dee055c00ac76bb079439aac4ec04897f00e1d43",
-                "reference": "dee055c00ac76bb079439aac4ec04897f00e1d43",
+                "url": "https://api.github.com/repos/symfony/FrameworkBundle/zipball/a796b26e4fa0afddadfd42e2fd374974dd68ced2",
+                "reference": "a796b26e4fa0afddadfd42e2fd374974dd68ced2",
                 "shasum": ""
             },
             "require": {
@@ -2390,20 +2391,20 @@
             ],
             "description": "Symfony FrameworkBundle",
             "homepage": "https://symfony.com",
-            "time": "2015-06-11 17:26:34"
+            "time": "2015-07-09 16:32:09"
         },
         {
             "name": "symfony/routing",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Routing.git",
-                "reference": "5581be29185b8fb802398904555f70da62f6d50d"
+                "reference": "ea9134f277162b02e5f80ac058b75a77637b0d26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Routing/zipball/5581be29185b8fb802398904555f70da62f6d50d",
-                "reference": "5581be29185b8fb802398904555f70da62f6d50d",
+                "url": "https://api.github.com/repos/symfony/Routing/zipball/ea9134f277162b02e5f80ac058b75a77637b0d26",
+                "reference": "ea9134f277162b02e5f80ac058b75a77637b0d26",
                 "shasum": ""
             },
             "require": {
@@ -2461,20 +2462,20 @@
                 "uri",
                 "url"
             ],
-            "time": "2015-06-11 17:20:40"
+            "time": "2015-07-09 16:07:40"
         },
         {
             "name": "symfony/security-core",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-core.git",
-                "reference": "08cd68cea42ad73476d3900e675662db363c8fba"
+                "reference": "de1a3aa7a298e99587f6082e4c5754a9b0dc0fcd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-core/zipball/08cd68cea42ad73476d3900e675662db363c8fba",
-                "reference": "08cd68cea42ad73476d3900e675662db363c8fba",
+                "url": "https://api.github.com/repos/symfony/security-core/zipball/de1a3aa7a298e99587f6082e4c5754a9b0dc0fcd",
+                "reference": "de1a3aa7a298e99587f6082e4c5754a9b0dc0fcd",
                 "shasum": ""
             },
             "require": {
@@ -2524,11 +2525,11 @@
             ],
             "description": "Symfony Security Component - Core Library",
             "homepage": "https://symfony.com",
-            "time": "2015-06-08 09:37:21"
+            "time": "2015-07-09 16:07:40"
         },
         {
             "name": "symfony/security-csrf",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-csrf.git",
@@ -2582,16 +2583,16 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Stopwatch.git",
-                "reference": "c653f1985f6c2b7dbffd04d48b9c0a96aaef814b"
+                "reference": "b07a866719bbac5294c67773340f97b871733310"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Stopwatch/zipball/c653f1985f6c2b7dbffd04d48b9c0a96aaef814b",
-                "reference": "c653f1985f6c2b7dbffd04d48b9c0a96aaef814b",
+                "url": "https://api.github.com/repos/symfony/Stopwatch/zipball/b07a866719bbac5294c67773340f97b871733310",
+                "reference": "b07a866719bbac5294c67773340f97b871733310",
                 "shasum": ""
             },
             "require": {
@@ -2627,20 +2628,20 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-04 20:11:48"
+            "time": "2015-07-01 18:23:16"
         },
         {
             "name": "symfony/templating",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Templating.git",
-                "reference": "3a2ed707230bae834ee24248a1a2a76f14eb3649"
+                "reference": "8e50f4d32dbbe4deedac6b92af414db8a7de2065"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Templating/zipball/3a2ed707230bae834ee24248a1a2a76f14eb3649",
-                "reference": "3a2ed707230bae834ee24248a1a2a76f14eb3649",
+                "url": "https://api.github.com/repos/symfony/Templating/zipball/8e50f4d32dbbe4deedac6b92af414db8a7de2065",
+                "reference": "8e50f4d32dbbe4deedac6b92af414db8a7de2065",
                 "shasum": ""
             },
             "require": {
@@ -2680,20 +2681,20 @@
             ],
             "description": "Symfony Templating Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-08 09:37:21"
+            "time": "2015-06-25 12:52:11"
         },
         {
             "name": "symfony/translation",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Translation.git",
-                "reference": "8349a2b0d11bd0311df9e8914408080912983a0b"
+                "reference": "c8dc34cc936152c609cdd722af317e4239d10dd6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Translation/zipball/8349a2b0d11bd0311df9e8914408080912983a0b",
-                "reference": "8349a2b0d11bd0311df9e8914408080912983a0b",
+                "url": "https://api.github.com/repos/symfony/Translation/zipball/c8dc34cc936152c609cdd722af317e4239d10dd6",
+                "reference": "c8dc34cc936152c609cdd722af317e4239d10dd6",
                 "shasum": ""
             },
             "require": {
@@ -2741,20 +2742,20 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-11 17:26:34"
+            "time": "2015-07-09 16:07:40"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Yaml.git",
-                "reference": "9808e75c609a14f6db02f70fccf4ca4aab53c160"
+                "reference": "4bfbe0ed3909bfddd75b70c094391ec1f142f860"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/9808e75c609a14f6db02f70fccf4ca4aab53c160",
-                "reference": "9808e75c609a14f6db02f70fccf4ca4aab53c160",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/4bfbe0ed3909bfddd75b70c094391ec1f142f860",
+                "reference": "4bfbe0ed3909bfddd75b70c094391ec1f142f860",
                 "shasum": ""
             },
             "require": {
@@ -2790,13 +2791,13 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-10 15:30:22"
+            "time": "2015-07-01 11:25:50"
         }
     ],
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "graviton/php-rql-parser": 15,
+        "graviton/php-rql-parser": 20,
         "lapistano/proxy-object": 20,
         "doctrine/mongodb-odm": 10
     },


### PR DESCRIPTION
I removed the ``Graviton\Rql\Parser`` class from ``graviton/php-rql-parser`` since it wasn't helping much.

With this change we stop using it and also more of the parser gets properly exposed as services.

I'll have some changes to graviton herself as well as more stuff here later...