### PR TITLE
RQL request listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,16 +66,15 @@ Despite the existence of unit tests, which are already examples how to use the f
 ```php
 [...]
 
-class foo {
-    public function __construct(Factory $rqlFactory) {
-        $this->rqlFactory = $rqlFactory;
-    }
+class FooController {
 
-    public function searchSomething($query) {
+    public function searchSomething(Request $request) {
     
-        $parser = $this->rqlFactory->create('myVisitor', $query);
-        
-        // do something with the parser.
+        if ($request->attributes('hasRql', false)) {
+            $query = $request->attributes->get('rqlQuery');
+
+            // do something with the query.
+        }
     }
 }
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,8 +21,8 @@
     <whitelist>
       <directory suffix=".php">.</directory>
         <exclude>
-            <directory>Tests</directory>
-            <directory>Resources</directory>
+            <directory>test</directory>
+            <directory>src/Resources</directory>
             <directory>vendor</directory>
         </exclude>
     </whitelist>

--- a/src/Listener/RequestListener.php
+++ b/src/Listener/RequestListener.php
@@ -17,6 +17,16 @@ use Xiag\Rql\Parser\Parser;
 class RequestListener
 {
     /**
+     * @var Lexer
+     */
+    private $lexer;
+
+    /**
+     * @var Parser
+     */
+    private $parser;
+
+    /**
      * @var string
      */
     private $queryKey;
@@ -36,14 +46,13 @@ class RequestListener
     /**
      * Validate the json input to prevent errors in the following components
      *
-     * @param RestEvent $event Event
+     * @param GetResponseEvent $event Event
      *
      * @return void|null
      */
     public function onKernelRequest(GetResponseEvent $event)
     {
         $request = $event->getRequest();
-        $filter = null;
 
         // grab unencoded version of rql extract q arg
         // has to grab the query direclty from _SERVER so it does not get unecoded by php beforehand
@@ -52,7 +61,7 @@ class RequestListener
             $filter = array_filter(
                 explode('&', $_SERVER['QUERY_STRING']),
                 function ($param) {
-                    return (substr($param, 0, 2) == $this->queryKey.'=');
+                    return (substr($param, 0, 2) == $this->queryKey . '=');
                 }
             );
             $filter = substr(reset($filter), 2);

--- a/src/Listener/RequestListener.php
+++ b/src/Listener/RequestListener.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Listen for requests containing rql queries and store the resulting queries AST in the request
+ */
+
+namespace Graviton\RqlParserBundle\Listener;
+
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Xiag\Rql\Parser\Lexer;
+use Xiag\Rql\Parser\Parser;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/GravitonRqlParserBundle/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class RequestListener
+{
+    /**
+     * @var string
+     */
+    private $queryKey;
+
+    /**
+     * @param Lexer  $lexer    rql lexer
+     * @param Parser $parser   rql parser
+     * @param string $queryKey name of query attribute to use
+     */
+    public function __construct(Lexer $lexer, Parser $parser, $queryKey)
+    {
+        $this->lexer = $lexer;
+        $this->parser = $parser;
+        $this->queryKey = $queryKey;
+    }
+
+    /**
+     * Validate the json input to prevent errors in the following components
+     *
+     * @param RestEvent $event Event
+     *
+     * @return void|null
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $request = $event->getRequest();
+        $filter = null;
+
+        // grab unencoded version of rql extract q arg
+        // has to grab the query direclty from _SERVER so it does not get unecoded by php beforehand
+        $filter = $request->query->get('q');
+        if (array_key_exists('QUERY_STRING', $_SERVER)) {
+            $filter = array_filter(
+                explode('&', $_SERVER['QUERY_STRING']),
+                function ($param) {
+                    return (substr($param, 0, 2) == $this->queryKey.'=');
+                }
+            );
+            $filter = substr(reset($filter), 2);
+        }
+        if (empty($filter)) {
+            return;
+        }
+        $request->attributes->set('hasRql', true);
+        $request->attributes->set('rawRql', $filter);
+        $request->attributes->set('rqlQuery', $this->parser->parse($this->lexer->tokenize($filter)));
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -8,6 +8,7 @@
         <parameter key="graviton.rql.lexer.class">Xiag\Rql\Parser\Lexer</parameter>
         <parameter key="graviton.rql.parser.class">Xiag\Rql\Parser\Parser</parameter>
         <parameter key="graviton.rql.visitor_factory.class">Graviton\RqlParserBundle\Factory</parameter>
+        <parameter key="graviton.rql.listener.request.class">Graviton\RqlParserBundle\Listener\RequestListener</parameter>
     </parameters>
     <services>
         <service id="graviton.rql.lexer" class="%graviton.rql.lexer.class%"/>
@@ -15,5 +16,11 @@
             <factory class="%graviton.rql.parser.class%" method="createDefault"/>
         </service>
         <service id="graviton.rql.visitor_factory" class="%graviton.rql.visitor_factory.class%"/>
+        <service id="graviton.rql.listener.request" class="%graviton.rql.listener.request.class%">
+            <argument type="service" id="graviton.rql.lexer"/>
+            <argument type="service" id="graviton.rql.parser"/>
+            <argument>q</argument>
+            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" />
+        </service>
     </services>
 </container>

--- a/test/Tests/Listener/RequestListenerTest.php
+++ b/test/Tests/Listener/RequestListenerTest.php
@@ -128,7 +128,7 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
     /**
      * @return array[]
      */
-    function willParseQueryData()
+    public function willParseQueryData()
     {
         return [
             'simple query string' => ['q=eq(foo,b%20a%20r)', 'eq(foo,b%20a%20r)'],

--- a/test/Tests/Listener/RequestListenerTest.php
+++ b/test/Tests/Listener/RequestListenerTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * validate listener
+ */
+
+namespace Graviton\RqlParserBundle\Tests\Listener;
+
+use Graviton\RqlParserBundle\Listener\RequestListener;
+
+/**
+ * @author List of contributors <https://github.com/libgraviton/GravitonRqlParserBundle/graphs/contributors>
+ * @license http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link http://swisscom.ch
+ */
+class RequestListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * check if nothing gets done when query is empty
+     */
+    public function testWillBehaveOnEmptyQuery()
+    {
+        $lexerDouble = $this->getMock('Xiag\Rql\Parser\Lexer');
+        $parserDouble = $this->getMockBuilder('Xiag\Rql\Parser\Parser')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $eventDouble = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $requestDouble = $this->getMock('Symfony\Component\HttpFoundation\Request');
+
+        $queryDouble = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
+        $queryDouble->expects($this->once())
+            ->method('get')
+            ->with('q')
+            ->willReturn('');
+        $requestDouble->query = $queryDouble;
+
+        $attributesDouble = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
+        $attributesDouble->expects($this->never())
+            ->method('set');
+        $requestDouble->attributes = $attributesDouble;
+
+        $eventDouble->expects($this->once())
+            ->method('getRequest')
+            ->willReturn($requestDouble);
+
+        $sut = new RequestListener(
+            $lexerDouble,
+            $parserDouble,
+            'q'
+        );
+
+        $sut->onKernelRequest($eventDouble);
+    }
+
+    /**
+     * test if queries get handled properly
+     */
+    public function testWillParseQuery()
+    {
+        $lexerDouble = $this->getMock('Xiag\Rql\Parser\Lexer');
+        $lexerDouble->expects($this->any())
+            ->method('tokenize')
+            ->willReturn(
+                $this->getMockBuilder('Xiag\Rql\Parser\TokenStream')
+                    ->disableOriginalConstructor()
+                    ->getMock()
+            );
+
+        $parserDouble = $this->getMockBuilder('Xiag\Rql\Parser\Parser')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $parserDouble->expects($this->once())
+            ->method('parse')
+            ->willReturn($this->getMock('Xiag\Rql\Parser\Query'));
+
+        $eventDouble = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $requestDouble = $this->getMock('Symfony\Component\HttpFoundation\Request');
+
+        $queryDouble = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
+        $queryDouble->expects($this->once())
+            ->method('get')
+            ->with('q')
+            ->willReturn('eq(foo,bar)');
+        $requestDouble->query = $queryDouble;
+
+        $attributesDouble = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
+        $attributesDouble->expects($this->at(0))
+            ->method('set')
+            ->with('hasRql', true);
+        $attributesDouble->expects($this->at(1))
+            ->method('set')
+            ->with('rawRql', 'eq(foo,bar)');
+        $attributesDouble->expects($this->at(2))
+            ->method('set')
+            ->with('rqlQuery', $this->isInstanceOf('Xiag\Rql\Parser\Query'));
+        $requestDouble->attributes = $attributesDouble;
+
+        $eventDouble->expects($this->once())
+            ->method('getRequest')
+            ->willReturn($requestDouble);
+
+        $sut = new RequestListener(
+            $lexerDouble,
+            $parserDouble,
+            'q'
+        );
+
+        $sut->onKernelRequest($eventDouble);
+    }
+}

--- a/test/Tests/Listener/RequestListenerTest.php
+++ b/test/Tests/Listener/RequestListenerTest.php
@@ -2,7 +2,6 @@
 /**
  * validate listener
  */
-
 namespace Graviton\RqlParserBundle\Tests\Listener;
 
 use Graviton\RqlParserBundle\Listener\RequestListener;

--- a/test/Tests/Listener/RequestListenerTest.php
+++ b/test/Tests/Listener/RequestListenerTest.php
@@ -16,6 +16,8 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * check if nothing gets done when query is empty
+     *
+     * @return void
      */
     public function testWillBehaveOnEmptyQuery()
     {
@@ -57,6 +59,8 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * test if queries get handled properly
+     *
+     * @return void
      */
     public function testWillParseQuery()
     {

--- a/test/Tests/Listener/RequestListenerTest.php
+++ b/test/Tests/Listener/RequestListenerTest.php
@@ -106,7 +106,7 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
             ->with('hasRql', true);
         $attributesDouble->expects($this->at(1))
             ->method('set')
-            ->with('rawRql', 'eq(foo,b%20a%20r)');
+            ->with('rawRql', $query);
         $attributesDouble->expects($this->at(2))
             ->method('set')
             ->with('rqlQuery', $this->isInstanceOf('Xiag\Rql\Parser\Query'));
@@ -133,6 +133,10 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
         return [
             'simple query string' => ['q=eq(foo,b%20a%20r)', 'eq(foo,b%20a%20r)'],
             'string with paging stuff' => ['page=1&q=eq(foo,b%20a%20r)&perPage=20', 'eq(foo,b%20a%20r)'],
+            'test with $ref in name' => [
+                'perPage=1&page=2&q=eq(name.%24ref,http%3A%2F%2Fexmaple.com)',
+                'eq(name.%24ref,http%3A%2F%2Fexmaple.com)'
+            ],
         ];
     }
 }


### PR DESCRIPTION
This request listener looks for a configurable query string and then attempts to parse it.

The results of this parsing are then stored into the ``$request->attributes`` parameter bag where they can later be retrieved from.

This decouples parsing from using the query and helps me refactor RestBundle/Model/DocumentModel in graviton.