### PR TITLE
Use full QUERY_STRING as RQL

### DIFF
--- a/src/Listener/RequestListener.php
+++ b/src/Listener/RequestListener.php
@@ -56,16 +56,7 @@ class RequestListener
 
         // grab unencoded version of rql extract q arg
         // has to grab the query direclty from _SERVER so it does not get unecoded by php beforehand
-        $filter = null;
-        if ($request->server->get('QUERY_STRING') !== null) {
-            $filter = array_filter(
-                explode('&', $request->server->get('QUERY_STRING')),
-                function ($param) {
-                    return (substr($param, 0, 2) == $this->queryKey . '=');
-                }
-            );
-            $filter = substr(reset($filter), 2);
-        }
+        $filter = $request->server->get('QUERY_STRING');
         if (empty($filter)) {
             return;
         }

--- a/test/Tests/Listener/RequestListenerTest.php
+++ b/test/Tests/Listener/RequestListenerTest.php
@@ -136,7 +136,7 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
                 'eq(name.%24ref,http%3A%2F%2Fexmaple.com)'
             ],
             'multiple rql statements' => [
-                'q=(a=2&(b<3|c>4)&like(e,123))&select(a,b)&sort(+a,-b)&limit(1,2)',
+                '(a=2&(b<3|c>4)&like(e,123))&select(a,b)&sort(+a,-b)&limit(1,2)',
                 '(a=2&(b<3|c>4)&like(e,123))&select(a,b)&sort(+a,-b)&limit(1,2)',
             ],
         ];

--- a/test/Tests/Listener/RequestListenerTest.php
+++ b/test/Tests/Listener/RequestListenerTest.php
@@ -92,7 +92,7 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
         $requestDouble = $this->getMock('Symfony\Component\HttpFoundation\Request');
 
         $serverDouble = $this->getMock('Symfony\Component\HttpFoundation\ServerBag');
-        $serverDouble->expects($this->exactly(2))
+        $serverDouble->expects($this->once())
             ->method('get')
             ->with('QUERY_STRING')
             ->willReturn($raw);
@@ -129,10 +129,10 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
     public function willParseQueryData()
     {
         return [
-            'simple query string' => ['q=eq(foo,b%20a%20r)', 'eq(foo,b%20a%20r)'],
-            'string with paging stuff' => ['page=1&q=eq(foo,b%20a%20r)&perPage=20', 'eq(foo,b%20a%20r)'],
+            'simple query string' => ['eq(foo,b%20a%20r)', 'eq(foo,b%20a%20r)'],
+            'string with paging stuff' => ['eq(foo,b%20a%20r)', 'eq(foo,b%20a%20r)'],
             'test with $ref in name' => [
-                'perPage=1&page=2&q=eq(name.%24ref,http%3A%2F%2Fexmaple.com)',
+                'eq(name.%24ref,http%3A%2F%2Fexmaple.com)',
                 'eq(name.%24ref,http%3A%2F%2Fexmaple.com)'
             ],
         ];


### PR DESCRIPTION
Everything else gives us neverending nightmares with getting rql form a query string.

We will also need to rip out ``perPage`` and ``page`` in graviton when we merge this.

This addresses #24